### PR TITLE
fix: update padding and spacing in footer and dynamic blog entry date

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,22 +1,22 @@
 ---
-const currentYear = new Date().getFullYear()
+const currentYear = new Date().getFullYear();
 ---
 
-<footer class='bg-gray-800 py-8 mt-auto'>
-  <div class='container mx-auto px-4 max-w-4xl'>
+<footer class="bg-gray-800 mt-auto p-8">
+  <div class="container mx-auto px-4 max-w-4xl">
     <div
-      class='flex flex-col justify-center md:flex-row md:justify-between items-center gap-4 mt-4'
+      class="flex flex-col justify-center md:flex-row md:justify-between items-center gap-4"
     >
-      <div class='text-gray-400 text-center text-sm'>
+      <div class="text-gray-400 text-center text-sm">
         © {currentYear} Share IT. Todos los derechos reservados.
       </div>
-      <div class='flex gap-2 text-sm' '>
+      <div class="flex gap-2 text-sm">
         <p>Una iniciativa de</p>
         <a
-          rel='noopener noreferrer'
-          target='_blank'
-          href='https://linkedin.com/in/victorqui'
-          class='text-gray-400 hover:text-[#83D6E7] font-bold'
+          rel="noopener noreferrer"
+          target="_blank"
+          href="https://linkedin.com/in/victorqui"
+          class="text-gray-400 hover:text-[#83D6E7] font-bold"
         >
           Victor Quiñones 🚀
         </a>

--- a/src/pages/articles/[slug].astro
+++ b/src/pages/articles/[slug].astro
@@ -21,11 +21,11 @@ const { Content } = await article.render()
     <header class='flex flex-col items-start gap-2'>
       <div class='flex flex-col items-start'>
         <h1 class='text-4xl font-bold text-white'>{article.data.title}</h1>
-        <time class='text-sm text-gray-400'
+        <time class='text-sm text-gray-400 mt-2'
           >{formatDate(article.data.date.toISOString())}</time
         >
       </div>
-      <div class='bg-[#314aa9] text-violet-200 px-3 py-1 rounded-full text-sm'>
+      <div class='bg-[#314aa9] text-violet-200 mt-2 px-3 py-1 rounded-full text-sm'>
         {article.data.category}
       </div>
       <p class='text-gray-300 mt-2'>{article.data.description}</p>


### PR DESCRIPTION
Hey Victor! 

I've updated some styles in the landing page footer as well as in the blog dynamic entries. I believe the padding and the margin bottom of these elements could be improved for better design consistency. Here are the screenshots of the improved versions:

![image](https://github.com/user-attachments/assets/894ef344-f254-4ca6-95b9-f92a1ceaf000)
![image](https://github.com/user-attachments/assets/8ff96ac5-7180-49ad-8529-c2a0856e75a0)
