### PR TITLE
Feature: Upgrade Content Collections API to the new Content Layer API

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,4 +1,5 @@
 import { defineCollection, z, reference } from 'astro:content'
+import { glob } from 'astro/loaders'
 
 const authorSchema = z.object({
   name: z.string(),
@@ -21,12 +22,12 @@ const articleSchema = z.object({
 })
 
 const articles = defineCollection({
-  //   type: 'content',
+    loader:  glob({ pattern: '**/*.md', base: "./src/content/articles" }),
   schema: articleSchema,
 })
 
 const authors = defineCollection({
-  type: 'data',
+    loader:  glob({ pattern: '**/*.yaml', base: "./src/content/authors" }),
   schema: authorSchema,
 })
 

--- a/src/pages/articles/[page].astro
+++ b/src/pages/articles/[page].astro
@@ -29,7 +29,7 @@ const {
 } = page as {
   data: Array<{
     data: { title: string; description: string; category: string; date: Date }
-    slug: string
+    id: string
   }>
   currentPage: number
   lastPage: number
@@ -60,7 +60,7 @@ const {
             description={article.data.description}
             category={article.data.category}
             date={article.data.date}
-            href={`/articles/${article.slug}`}
+            href={`/articles/${article.id}`}
           />
         ))
       )

--- a/src/pages/articles/[slug].astro
+++ b/src/pages/articles/[slug].astro
@@ -1,20 +1,20 @@
 ---
 import CollaboratorCard from '@components/CollaboratorCard.astro'
 import Layout from '@layouts/Layout.astro'
-import { getCollection, getEntry } from 'astro:content'
+import { getCollection, getEntry, render } from 'astro:content'
 import { formatDate } from 'src/utils/dates'
 
 export async function getStaticPaths() {
   const articles = await getCollection('articles')
   return articles.map((article) => ({
-    params: { slug: article.slug },
+    params: { slug: article.id },
     props: { article },
   }))
 }
 
 const { article } = Astro.props
 const author = await getEntry(article.data.author)
-const { Content } = await article.render()
+const { Content } = await render(article)
 ---
 
 <Layout title={article.data.title} showBackButton>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -13,6 +13,7 @@ const articles = await getCollection('articles', ({ data }) => {
 const latestArticles = articles
   .sort((a, b) => b.data.date.getTime() - a.data.date.getTime())
   .slice(0, 2)
+
 const latestResources = resources.slice(0, 2)
 
 export const prerender = true
@@ -68,7 +69,7 @@ export const prerender = true
             description={article.data.description}
             category={article.data.category}
             date={article.data.date}
-            href={`/articles/${article.slug}`}
+            href={`/articles/${article.id}`}
           />
         ))
       }


### PR DESCRIPTION
The following changes have been introduced:

- Move content collection config file to src path.
- Change old slug field to id and old entry render method to new render function utility.

These changes are made in order to avoid future breaking changes when Astro removes the old Content Collections API backwards compatibility implementation.